### PR TITLE
feat: support multichain domains in the types contract

### DIFF
--- a/.changeset/ninety-clouds-jog.md
+++ b/.changeset/ninety-clouds-jog.md
@@ -1,0 +1,5 @@
+---
+"@nftchance/plug-types": patch
+---
+
+feat: multichain domains in signatures

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 
 build/Release
+chains.json
 
 # Dependency directories
 

--- a/package.json
+++ b/package.json
@@ -1,89 +1,89 @@
 {
-	"name": "@nftchance/plug-types",
-	"version": "0.9.5",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/nftchance/plug-types.git"
-	},
-	"keywords": [
-		"nftchance",
-		"eip712",
-		"typehash",
-		"signatures",
-		"eth",
-		"ethereum",
-		"solidity",
-		"crypto",
-		"intent",
-		"plugs",
-		"plug"
-	],
-	"sideEffects": false,
-	"scripts": {
-		"dev": "DEV=true tsup",
-		"prebuild": "tsup && pnpm plug zod && pnpm lint",
-		"build": "tsup && pnpm plug generate && pnpm plug docs",
-		"plug": "node dist/core/cli.mjs",
-		"lint": "tsc --noEmit",
-		"format": "pnpm prettier --write ."
-	},
-	"publishConfig": {
-		"access": "public"
-	},
-	"dependencies": {
-		"@trivago/prettier-plugin-sort-imports": "^4.2.1",
-		"abitype": "^1.0.2",
-		"bundle-require": "^4.0.2",
-		"commander": "^12.0.0",
-		"dedent": "^1.5.1",
-		"ethers": "^6.11.1",
-		"execa": "^8.0.1",
-		"find-up": "^7.0.0",
-		"fs-extra": "^11.2.0",
-		"pathe": "^1.1.2",
-		"picocolors": "^1.0.0",
-		"prettier": "^3.2.5",
-		"solady": "^0.0.177",
-		"tsx": "^4.7.1",
-		"zod": "^3.22.4"
-	},
-	"devDependencies": {
-		"@changesets/cli": "^2.27.1",
-		"@types/dedent": "^0.7.0",
-		"@types/fs-extra": "^11.0.2",
-		"@types/node": "^20.11.28",
-		"tsup": "^8.0.2",
-		"typescript": "^5.4.2"
-	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
-	"bin": {
-		"plug": "dist/core/cli.mjs"
-	},
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
-		},
-		"./core/cli": {
-			"types": "./dist/core/cli.d.ts",
-			"default": "./dist/core/cli.js"
-		},
-		"./zod": {
-			"types": "./dist/zod/index.d.ts",
-			"default": "./dist/zod/index.js"
-		},
-		"./zod/types": {
-			"types": "./dist/zod/types.d.ts",
-			"default": "./dist/zod/types.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"files": [
-		"/core",
-		"/zod",
-		"/dist"
-	]
+  "name": "@nftchance/plug-types",
+  "version": "0.9.5",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nftchance/plug-types.git"
+  },
+  "keywords": [
+    "nftchance",
+    "eip712",
+    "typehash",
+    "signatures",
+    "eth",
+    "ethereum",
+    "solidity",
+    "crypto",
+    "intent",
+    "plugs",
+    "plug"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "dev": "DEV=true tsup",
+    "prebuild": "tsup && pnpm plug zod && pnpm lint",
+    "build": "tsup && pnpm plug generate && pnpm plug docs",
+    "plug": "node dist/core/cli.mjs",
+    "lint": "tsc --noEmit",
+    "format": "pnpm prettier --write ."
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.2.1",
+    "abitype": "^1.0.2",
+    "bundle-require": "^4.0.2",
+    "commander": "^12.0.0",
+    "dedent": "^1.5.1",
+    "ethers": "^6.11.1",
+    "execa": "^8.0.1",
+    "find-up": "^7.0.0",
+    "fs-extra": "^11.2.0",
+    "pathe": "^1.1.2",
+    "picocolors": "^1.0.0",
+    "prettier": "^3.2.5",
+    "solady": "^0.0.177",
+    "tsx": "^4.7.1",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.27.1",
+    "@types/dedent": "^0.7.0",
+    "@types/fs-extra": "^11.0.2",
+    "@types/node": "^20.11.28",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.2"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "bin": {
+    "plug": "dist/core/cli.mjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./core/cli": {
+      "types": "./dist/core/cli.d.ts",
+      "default": "./dist/core/cli.js"
+    },
+    "./zod": {
+      "types": "./dist/zod/index.d.ts",
+      "default": "./dist/zod/index.js"
+    },
+    "./zod/types": {
+      "types": "./dist/zod/types.d.ts",
+      "default": "./dist/zod/types.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "/core",
+    "/zod",
+    "/dist"
+  ]
 }

--- a/src/core/sol.ts
+++ b/src/core/sol.ts
@@ -1,4 +1,4 @@
-import { ethers, keccak256, TypedDataEncoder } from 'ethers'
+import { ethers, TypedDataEncoder } from 'ethers'
 
 import { TypedData, TypedDataParameter } from 'abitype'
 import { TypedDataType } from 'abitype/zod'
@@ -342,9 +342,9 @@ export function getSolidity(config: Config) {
      * }>>`
 
 		const typeHashImplementation = `
-    bytes32 constant ${typeHashName} = ${keccak256(
-		encoder.encodeType(typeName)
-	)};`
+    bytes32 constant ${typeHashName} = keccak256(
+        '${encoder.encodeType(typeName)}'
+    );`
 
 		const nestedTypes = type
 			.map(field => field.type.replace('[]', ''))

--- a/src/core/sol.ts
+++ b/src/core/sol.ts
@@ -775,7 +775,7 @@ abstract contract ${config.contract.name} {
             ///      we have not found a match then we can revert the transaction as the chainId
             ///      is not valid for the provided signature.
             if (chainId == 0) {
-                revert("PlugTypes:invalid-chainId");
+                revert("${config.contract.name}:invalid-chainId");
             }
         }
 
@@ -785,7 +785,7 @@ abstract contract ${config.contract.name} {
         ///      is revoked it will need to be revoked on all chains that it is valid on
         ///      otherwise the use of the signature on an unrevoked chain will still be valid.
         $domainHash = getEIP712DomainHash(
-            PlugTypesLib.EIP712Domain({
+            ${config.contract.name}Lib.EIP712Domain({
                 name: name(),
                 version: version(),
                 chainId: $chainId,

--- a/src/core/sol.ts
+++ b/src/core/sol.ts
@@ -1,4 +1,4 @@
-import { ethers, TypedDataEncoder } from 'ethers'
+import { ethers, keccak256, toUtf8Bytes, TypedDataEncoder } from 'ethers'
 
 import { TypedData, TypedDataParameter } from 'abitype'
 import { TypedDataType } from 'abitype/zod'
@@ -342,9 +342,8 @@ export function getSolidity(config: Config) {
      * }>>`
 
 		const typeHashImplementation = `
-    bytes32 constant ${typeHashName} = keccak256(
-        '${encoder.encodeType(typeName)}'
-    );`
+    bytes32 constant ${typeHashName} = 
+	${keccak256(toUtf8Bytes(encoder.encodeType(typeName)))};`
 
 		const nestedTypes = type
 			.map(field => field.type.replace('[]', ''))

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,6 +28,7 @@ export const PLUGS_TYPES = {
 	],
 	Plugs: [
 		{ name: 'socket', type: 'address' },
+		{ name: 'chainId', type: 'uint256' },
 		{ name: 'plugs', type: 'Plug[]' },
 		{ name: 'salt', type: 'bytes32' },
 		{ name: 'fee', type: 'uint256' },


### PR DESCRIPTION
This version of multichain support prioritizes realism over future composability. By default, Sockets should be upgradeable therefore when the time eventually comes that domains can be within a full range of `uint64` then it will matter. For now, all critical chains are supported with `uint32`.

It is standardized that chainIds should never exceed `uint64` so in the future that will be the target. The reason this is not done today is because that only allows for `4` chains in a  single signature while there are multiple protocols that we will want to support with a much wider range of intents.